### PR TITLE
Debug api connection error

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -30,7 +30,8 @@ export default {
     },
     plugins: ['expo-router'],
     extra: {
-      API_URL: process.env.API_URL,
+      // Utilise la variable publique Expo pour l'API, compatible build EAS
+      API_URL: process.env.EXPO_PUBLIC_API_URL,
       eas: {
         projectId: '2f0473dd-d49f-4fe8-8644-8ae4516c7d09',
       },

--- a/eas.json
+++ b/eas.json
@@ -12,6 +12,9 @@
     "preview": {
       "distribution": "internal",
       "channel": "preview",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://giftsquad-back.onrender.com"
+      },
       "android": {
         "buildType": "apk"
       }
@@ -19,6 +22,9 @@
     "production": {
       "autoIncrement": true,
       "channel": "production",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://giftsquad-back.onrender.com"
+      },
       "android": {
       "buildType": "app-bundle"
       }

--- a/services/api.js
+++ b/services/api.js
@@ -7,14 +7,25 @@ import axios from 'axios';
 import Constants from 'expo-constants';
 import { router } from 'expo-router';
 
-// Récupération de l'URL de l'API depuis la configuration Expo
+// Récupération de l'URL de l'API depuis les variables publiques Expo et extras
+// Priorité: EXPO_PUBLIC_API_URL (inlinée au build) -> extra d'Expo (expo/dev) -> extra d'Expo Go
 // http://10.0.2.2:3000 (émulateur Android)
-const API_BASE_URL = Constants.expoConfig?.extra?.API_URL;
+const ENV_API_URL = process.env.EXPO_PUBLIC_API_URL;
+const API_BASE_URL =
+  ENV_API_URL ||
+  Constants.expoConfig?.extra?.API_URL ||
+  Constants.expoGoConfig?.extra?.API_URL;
+
+if (!API_BASE_URL) {
+  // Aide au debug: éviter les appels relatifs qui échouent en production Android
+  console.warn('[API] Aucune API_BASE_URL définie. Vérifiez EXPO_PUBLIC_API_URL ou extra.API_URL');
+}
 
 // Créer une instance axios
 const api = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 10_000,
+  // Render/Northflank peuvent avoir un cold start: on laisse plus de marge
+  timeout: 30_000,
 });
 
 // Interceptor pour ajouter automatiquement le token


### PR DESCRIPTION
Improve API URL resolution and increase timeout to fix network errors in Android release builds.

The previous API URL resolution was unreliable for Android release builds, leading to an undefined `baseURL` for Axios. This change ensures `EXPO_PUBLIC_API_URL` is correctly used, and increases the timeout to better handle potential cold starts of the backend server.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5d5f2d9-895f-4b71-a96e-f7fd516281e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5d5f2d9-895f-4b71-a96e-f7fd516281e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

